### PR TITLE
Ignore legacy format file

### DIFF
--- a/Sources/IBLinterCore/InterfaceBuilderParser.swift
+++ b/Sources/IBLinterCore/InterfaceBuilderParser.swift
@@ -5,6 +5,9 @@
 //  Created by SaitoYuta on 2017/12/05.
 //
 
+private let cocoaTouchKey = "com.apple.InterfaceBuilder3.CocoaTouch.XIB"
+private let cocoaKey = "com.apple.InterfaceBuilder3.Cocoa.XIB"
+
 public struct InterfaceBuilderParser {
 
     private let xmlParser: XMLParserProtocol
@@ -16,7 +19,19 @@ public struct InterfaceBuilderParser {
     public func parseStoryboard(xml: String) throws -> InterfaceBuilderNode.StoryboardDocument {
         let root = xmlParser.parseString(xml)
         guard let document: XMLIndexerProtocol = root.byKey("document") else {
-            throw Error.invalidFormatFile
+            guard let archive: XMLIndexerProtocol = root.byKey("archive"),
+                let type: String = try? archive.attributeValue(of: "type") else {
+                throw Error.invalidFormatFile
+            }
+
+            switch type {
+            case cocoaTouchKey:
+                throw Error.legacyFormat
+            case cocoaKey:
+                throw Error.macFormat
+            default:
+                throw Error.invalidFormatFile
+            }
         }
         return try decodeValue(document)
     }
@@ -24,12 +39,26 @@ public struct InterfaceBuilderParser {
     public func parseXib(xml: String) throws -> InterfaceBuilderNode.XibDocument {
         let root = xmlParser.parseString(xml)
         guard let document: XMLIndexerProtocol = root.byKey("document") else {
-            throw Error.invalidFormatFile
+            guard let archive: XMLIndexerProtocol = root.byKey("archive"),
+                let type: String = try? archive.attributeValue(of: "type") else {
+                    throw Error.invalidFormatFile
+            }
+
+            switch type {
+            case cocoaTouchKey:
+                throw Error.legacyFormat
+            case cocoaKey:
+                throw Error.macFormat
+            default:
+                throw Error.invalidFormatFile
+            }
         }
         return try decodeValue(document)
     }
 
     public enum Error: Swift.Error {
         case invalidFormatFile
+        case legacyFormat
+        case macFormat
     }
 }

--- a/Sources/IBLinterKit/Commands/ValidateCommand.swift
+++ b/Sources/IBLinterKit/Commands/ValidateCommand.swift
@@ -50,6 +50,12 @@ struct ValidateCommand: CommandProtocol {
                 case .invalidFormatFile:
                     print("\($0.relativePath) is invalid format and skipped")
                     return nil
+                case .legacyFormat:
+                    print("\($0.relativePath) is legacy format. Please open with latest Xcode to migrate.")
+                    return nil
+                case .macFormat:
+                    print("\($0.relativePath) is mac format and skipped.")
+                    return nil
                 }
             } catch let error {
                 fatalError("parse error \($0.relativePath): \(error)")
@@ -70,6 +76,12 @@ struct ValidateCommand: CommandProtocol {
                 switch error {
                 case .invalidFormatFile:
                     print("\($0.relativePath) is invalid format and skipped")
+                    return nil
+                case .legacyFormat:
+                    print("\($0.relativePath) is legacy format. Please open with latest Xcode to migrate.")
+                    return nil
+                case .macFormat:
+                    print("\($0.relativePath) is mac format and skipped.")
                     return nil
                 }
             } catch let error {


### PR DESCRIPTION
Changed to check whether `AppKit` format or legacy `UIKit` format.
https://github.com/kateinoigakukun/IBLinter/issues/15