### PR TITLE
CocoaPods: Set binaries as preserved paths instead of source files

### DIFF
--- a/IBLinter.podspec
+++ b/IBLinter.podspec
@@ -6,5 +6,5 @@ Pod::Spec.new do |s|
   s.license        = { :type => 'MIT', :file => 'LICENSE' }
   s.author         = { 'Yuta Saito' => 'kateinoigakukun@gmail.com' }
   s.source         = { :git => "https://github.com/kateinoigakukun/IBLinter.git", :tag => s.version }
-  s.source_files   = 'bin/*'
+  s.preserve_paths = 'bin/*'
 end


### PR DESCRIPTION
Currently gives warning when building, `no rule to process file ‘Pods/IBLinter/bin/iblinter’ of type compiled.mach-o.executable for architecture x86_64`

This also avoids CocoaPods declaring IBLinter as a required framework for targets