### PR TITLE
Ensure enabled rules are unique

### DIFF
--- a/Sources/IBLinterKit/Config.swift
+++ b/Sources/IBLinterKit/Config.swift
@@ -27,6 +27,12 @@ public struct Config: Codable {
         enabledRules = []
         excluded = []
     }
+    
+    init(disabledRules: [String], enabledRules: [String], excluded: [String]) {
+        self.disabledRules = disabledRules
+        self.enabledRules = enabledRules
+        self.excluded = excluded
+    }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/IBLinterKit/Rules/Rule.swift
+++ b/Sources/IBLinterKit/Rules/Rule.swift
@@ -36,7 +36,10 @@ public struct Rules {
     }
 
     static func rules(_ config: Config) -> [Rule] {
-        return (defaultRules.filter { !config.disabledRules.contains($0.identifier) }
-            + allRules.filter { config.enabledRules.contains($0.identifier) }).map { $0.init() }
+        var identifiers = Set(defaultRules.map({ $0.identifier }))
+        identifiers.subtract(config.disabledRules)
+        identifiers.formUnion(config.enabledRules)
+        
+        return allRules.filter { identifiers.contains($0.identifier) }.map { $0.init() }
     }
 }

--- a/Tests/IBLinterKitTest/RuleTest.swift
+++ b/Tests/IBLinterKitTest/RuleTest.swift
@@ -1,5 +1,5 @@
 import IBLinterCore
-import IBLinterKit
+@testable import IBLinterKit
 import XCTest
 
 class RuleTest: XCTestCase {
@@ -23,6 +23,30 @@ class RuleTest: XCTestCase {
         let rule = Rules.DuplicateConstraintRule.init()
         let violations = try! rule.validate(xib: XibFile.init(path: path))
         XCTAssertEqual(violations.count, 2)
+    }
+    
+    func testDefaultEnabledRules() {
+        let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
+        let config = Config(disabledRules: [], enabledRules: [], excluded: [])
+        let rules = Rules.rules(config)
+        XCTAssertEqual(Set(rules.map({ type(of:$0).identifier })), Set(defaultEnabledRules))
+        XCTAssertEqual(rules.count, defaultEnabledRules.count)
+    }
+    
+    func testDisableDefaultEnabledRules() {
+        let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
+        let config = Config(disabledRules: defaultEnabledRules, enabledRules: [], excluded: [])
+        let rules = Rules.rules(config)
+        XCTAssertEqual(Set(rules.map({ type(of:$0).identifier })), Set())
+        XCTAssertEqual(rules.count, 0)
+    }
+    
+    func testDuplicatedEnabledRules() {
+        let defaultEnabledRules = Rules.defaultRules.map({ $0.identifier })
+        let config = Config(disabledRules: [], enabledRules: defaultEnabledRules, excluded: [])
+        let rules = Rules.rules(config)
+        XCTAssertEqual(Set(rules.map({ type(of:$0).identifier })), Set(defaultEnabledRules))
+        XCTAssertEqual(rules.count, defaultEnabledRules.count)
     }
 }
 


### PR DESCRIPTION
Avoids the same rule(s) being executed multiple times and showing the same error more than once.